### PR TITLE
Fixes hang when a password or a db is used in the connection string

### DIFF
--- a/lib/redis_client/redis_connection.dart
+++ b/lib/redis_client/redis_connection.dart
@@ -338,15 +338,13 @@ class _RedisConnection extends RedisConnection {
 
     logger.finest("Sending message ${UTF8.decode(cmdWithArgs[0])}");
 
-    connected.then((_) {
-      _socket.add("*${cmdWithArgs.length}\r\n".codeUnits);
-      cmdWithArgs.forEach((line) {
-        _socket.add("\$${line.length}\r\n".codeUnits);
+    _socket.add("*${cmdWithArgs.length}\r\n".codeUnits);
+    cmdWithArgs.forEach((line) {
+      _socket.add("\$${line.length}\r\n".codeUnits);
 
-        // Write the line, and the line end
-        _socket.add(line);
-        _socket.add(_lineEnd);
-      });
+      // Write the line, and the line end
+      _socket.add(line);
+      _socket.add(_lineEnd);
     });
 
     _pendingResponses.add(response);


### PR DESCRIPTION
Not sure if this is the best way to fix this issue, but I ran into a problem where calls to RedisCliient.connect() would hang anytime I passed in a db to the connection string using Dart SDK 1.0.0.7_r30338 and Redis 2.6.7

For example, doing something like:

``` dart
void main() {
  var connectionString = "127.0.0.1:6379/1";

  RedisClient.connect(connectionString)
    .then((RedisClient client) {
      print("client connected");

      client.set("test", "value")
        .then((_) => client.close());
  });
}
```

would never print "client connected", but would work fine if I removed the /db part of the connection string or set it to /0

Seems that there's an issue calling select() (and thus rawSend which has a dependency on the 'connected' future) from the same code block that you use to set the 'connected' future. https://github.com/dartist/redis_client/blob/9311b2ce01634c0cdcdf0600925682cc00fd3fdf/lib/redis_client/redis_connection.dart#L228

The same issue seems to happen when you call _authenticate from:
https://github.com/dartist/redis_client/blob/9311b2ce01634c0cdcdf0600925682cc00fd3fdf/lib/redis_client/redis_connection.dart#L225
