### PR TITLE
added failing test case bracketed in hardcoded false that shows that

### DIFF
--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -1573,7 +1573,18 @@ class RedisClient {
    * Unubscribes from [List<String>] channels 
    */
   Future unsubscribe(List<String> channels) => connection.unsubscribe(channels);
-  
+
+  /**
+   * Psubscribes to [List<String> ] channels
+   * with [Function] onMessage handler
+   */
+  Future psubscribe(List<String> patterns, Function onMessage) => connection.psubscribe(patterns, onMessage);
+
+  /**
+   * Punubscribes from [List<String>] channels
+   */
+  Future punsubscribe(List<String> patterns) => connection.punsubscribe(patterns);
+       
   /**
    * Publishes [String] message to [String] channel 
    * map when key does not exist.

--- a/test/redis_pubsub_tests.dart
+++ b/test/redis_pubsub_tests.dart
@@ -56,6 +56,46 @@ main() {
         }));
       });
     
+
+    test("psubscribe & publish", () {
+      async(
+      client.psubscribe(["chan0.*"],(Receiver message){
+        message.receiveMultiBulkStrings().then((List<String> message){
+          expect(message[0], equals("pmessage"));
+          expect(message[1], equals("chan0.*"));
+          expect(message[2], equals("chan0.wow"));
+          expect(message[3], equals("You okay?"));
+          });
+        }).then((m){
+          client1.publish("chan0.wow","You okay?");
+        }));
+      });
+
+    // TODO: Add in following test when support for the API works
+    if(false) {
+      test("subscribe & publish multiple channels", () {
+        async(
+            client.subscribe(["chan0","chan1", "chan2"],(Receiver message){
+              print('Got subscription message ${message.reply}');
+              message.receiveMultiBulkStrings().then((List<String> message){
+                print("Message is $message");
+                expect(message[0], equals("message"));
+                expect(message[1], anyOf(equals("chan0"), equals("chan1")));
+                if(message[1] == "chan0") {
+                  expect(message[2], equals("You okay?"));
+                } else {
+                  expect(message[2], equals("How about you?"));
+                }
+              });
+            }).then((m){
+                  client1.publish("chan0","You okay?")
+                    .then((_) => print('Published you okay?'));
+                  client1.publish("chan1","How about you?")
+                    .then((_) => print('Published How about you?'));
+                }));
+      });
+    }
+    
     test("Can work after unsubscribe", () {
       
       bool gotMessage = false;
@@ -73,6 +113,22 @@ main() {
           }).then((a) => client1.publish("chan0","You okay?"))            
       );
       
+    });
+
+    test("Can work after punsubscribe", () {
+      bool gotMessage = false;
+      async(
+          client.psubscribe(["chan0.*"],(Receiver message){
+            return message.receiveMultiBulkStrings().then((List<String> message){
+              gotMessage = true;
+            }).then((bb)=>  client.punsubscribe(["chan0.*"]))
+             .then((v) => client.set("key", "val"))
+             .then((c1) => client.get("key"))
+                 .then((ttt){
+                   expect(ttt, equals("val"));
+             });
+          }).then((a) => client1.publish("chan0.wow","You okay?"))
+      );
     });
     
     


### PR DESCRIPTION
subscribing to multiple channels fails

added support for psubscribe/punsubscribe with same existing
limitation in that it only works if there is one channel

I believe the current approach is problematic. The issue is when sending a (p)subscribe with more than one channel, which is not covered in the tests, the handler expects only one reply from redis, but there will be N where N is the number of channels. Maybe there is a quick fix to address this, but in playing around I did not find one.

Another issue is it looks like the public API should support multiple subscribe calls, like redis does. However the problem with this API is there is only one subscription handler, so this type of code will not work:

   client.subscribe(["monster"], monsterHandler);
   client.subscribe(["ghost"], ghostHandler);

In general I think the subscribe/unsubscribe API should be rethought and made more user friendly.