### PR TITLE
Fixing transformer crash on Null Arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## 0.1.17
+
+- Fix crash on Null Arrays
+
 ## 0.1.16
 
 - Version roll logger

--- a/lib/transformer/transformer.dart
+++ b/lib/transformer/transformer.dart
@@ -236,8 +236,9 @@ class _MultiBulkConsumer extends _RedisConsumer {
     if(_replies == null) {
       current = _lineConsumer.consume(data, current, end);
       if(_lineConsumer.done) {
-        final numReplies =
+        final numRepliesOnWire =
           int.parse(new String.fromCharCodes(_lineConsumer.data));
+        final numReplies = numRepliesOnWire == -1 ? 0 : numRepliesOnWire;
         _replies = new List<RedisReply>(numReplies);
       }
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: redis_client
-version: 0.1.16
+version: 0.1.17
 authors:
 - Demis Bellot <demis.bellot@gmail.com>
 - Adam Singer <financeCoding@gmail.com>

--- a/test/redis_client_tests.dart
+++ b/test/redis_client_tests.dart
@@ -916,8 +916,14 @@ invalid_line
           .then((blpopResult) => expect(blpopResult, equals({'list1':'a'})))
       );
     });
-    
-    test('BRPOP', () { 
+
+    test('BLPOP - with timeout', () {
+      async(
+          client.blpop(['list1'], timeout: 1).
+          then((blpopResult) => expect(blpopResult, equals({}))));
+    });
+
+    test('BRPOP', () {
       async(
           client.rpush('list1', ['a', 'b', 'c'])
           .then((_) => client.brpop(['list1', 'list2'], timeout: 0))


### PR DESCRIPTION
Redis [return Null Arrays](http://redis.io/topics/protocol#resp-arrays) in specific situations (e.g. BLPOP timeouts or EXEC if aborting).

Before this commit, `_MultiBulkConsumer`crashed with a RangeError, while trying to create a List with `-1` lenght.

Redis doc states:

> A client library API should return a null object and not an empty Array when Redis replies with a Null Array

This simple fix does not comply with this suggestion. A larger rework would be required to return a Null object.
