### PR TITLE
Fix hsetnx command

### DIFF
--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -1447,7 +1447,7 @@ class RedisClient {
    * If field already exists, this operation has no effect.
    */
   Future<bool> hsetnx(String hashId, String key, Object value) => 
-      connection.sendCommandWithVariadicValues(RedisCommand.HSETNX, [ key ], 
+      connection.sendCommandWithVariadicValues(RedisCommand.HSETNX, [ hashId, key ], 
           serializer.serializeToList(value)).receiveBool();
   
   /**

--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -2,6 +2,8 @@ part of redis_client;
 
 const exclusive = '(';
 
+typedef SubscriptionCallback = Function(Receiver receiver);
+
 /**
  * The [RedisClient] is a high level class to access your redis server.
  *
@@ -1577,7 +1579,7 @@ class RedisClient {
    * Subscribes to [List<String> ] channels 
    * with [Function] onMessage handler
    */
-  Future subscribe(List<String> channels, Function onMessage) => connection.subscribe(channels, onMessage);      
+  Future subscribe(List<String> channels, SubscriptionCallback onMessage) => connection.subscribe(channels, onMessage);      
   
   /**
    * Unubscribes from [List<String>] channels 

--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -1590,7 +1590,7 @@ class RedisClient {
    * Publishes [String] message to [String] channel 
    * map when key does not exist.
    */
-  Future publish(String channel, String message) => 
+  Future<int> publish(String channel, String message) => 
       connection.sendCommand(RedisCommand.PUBLISH, [channel,message])
         .receiveInteger();
   

--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -305,6 +305,14 @@ class RedisClient {
       connection.sendCommand(RedisCommand.PSETEX, 
           [ key, expireInMs.toString(), value ]).receiveStatus("OK");
 
+  /// If [key] does not exist, the key is added with the value of [value],
+  /// and true is returned.
+  ///
+  /// If [key] does exist, this operation has no effect and false is returned.
+  Future<bool> setnx(String key, Object value) =>
+      connection.sendCommandWithVariadicValues(RedisCommand.SETNX, [ key ],
+          serializer.serializeToList(value)).receiveBool();
+
   /**
    * Remove the existing timeout on key.
    *

--- a/lib/redis_client/redis_client.dart
+++ b/lib/redis_client/redis_client.dart
@@ -62,6 +62,8 @@ class RedisClient {
   Map get stats => connection.stats;
 
   Future close() => connection.close();
+  
+  bool get isConnected => connection.isConnected;
 
 
 

--- a/lib/redis_client/redis_connection.dart
+++ b/lib/redis_client/redis_connection.dart
@@ -73,7 +73,7 @@ abstract class RedisConnection {
 
 
   /// Subscribes to [List<String>] channels with [Function] onMessage handler
-  Future subscribe(List<String> channels, Function onMessage);
+  Future subscribe(List<String> channels, SubscriptionCallback onMessage);
 
 
   /// Unubscribes from [List<String>] channels
@@ -218,9 +218,9 @@ class _RedisConnection extends RedisConnection {
     throw new RedisClientException("Socket error $err.");
   }
 
-  Function _subscriptionHandler = null;
+  SubscriptionCallback _subscriptionHandler = null;
 
-  Future subscribe(List<String> channels, Function onMessage){
+  Future subscribe(List<String> channels, SubscriptionCallback onMessage){
 
     Completer subscribeCompleter = new Completer();
     List<String> args = new List <String>()


### PR DESCRIPTION
Hash id was not being sent to redis. Therefore, any time this command was used, a redis error would be returned.
